### PR TITLE
Updates Closes #7 Added Header to Notes path

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ function App() {
 
       <Router basename={'notes-app'}>
         <Routes>
-          <Route exact path='/' element={ <><Header /> <Notes /></> } />
+          <Route exact path='/' element={ <Notes /> } />
           <Route exact path='/sign-in' element={ <SignIn /> } />
           <Route exact path='/sign-up' element={ <SignUp /> } />
         </Routes>

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -2,13 +2,37 @@ import { useEffect, useState } from 'react';
 import Loader from 'react-loaders';
 import './styles.scss';
 
-const Header = () => {
-    let [user, setUser] = useState(undefined);
+const useLocalStorage = (key) => {
+    const [value, setValue] = useState(null);
 
     useEffect(() => {
-        let user = JSON.parse(localStorage.getItem('user'));
-        setUser(user);
-    }, []);
+      const updateValue = (event) => {
+        if (event.key === null) {
+          // localStorage was cleared, null-out the value
+          setValue(null);
+        } else if (event.key === key) {
+          // the value we're watching changed. Update it.
+          setValue(JSON.parse(event.newValue).username);
+        }
+      }
+      // User already exists in local storage
+      let user = JSON.parse(localStorage.getItem('user'))?.username;
+      if (user) {
+        setValue(user);
+      }
+
+      // Register and clean-up event handler to listen to localstorage updates
+      window.addEventListener('storage', updateValue, false);
+      return () => {
+        window.removeEventListener('storage', updateValue, false);
+      }
+    }, [key]);
+
+    return value;
+  }
+
+const Header = () => {
+    const user = useLocalStorage('user');
 
     return (
         <div className="header">
@@ -16,12 +40,12 @@ const Header = () => {
                 <i className='bx bxs-dashboard bx-md'></i>
                 <span className='bx-sm'>Notes</span>
             </div>
-            
+
             <div className="r">
                 {user === undefined ? <Loader type='ball-pulse' /> : (
                     <>
                         <i className='bx bx-user bx-md'></i>
-                        <span>{user?.username}</span>
+                        <span>{user}</span>
                     </>
                 )}
             </div>

--- a/src/components/Sign-in/sign_in.js
+++ b/src/components/Sign-in/sign_in.js
@@ -21,7 +21,12 @@ export const sign_in_user = (user, div, nav) => {
                 if (data.err) {
                     div.current.innerText = data.err
                 } else {
+                    const evt = document.createEvent('StorageEvent');
+                    evt.initStorageEvent('storage', false, false, 'user', '', JSON.stringify(data),null, window.localStorage);
+
                     localStorage.setItem('user', JSON.stringify(data))
+
+                    window.dispatchEvent(evt);
                     nav('/')
                 }
             })

--- a/src/components/Sign-up/sign_up.js
+++ b/src/components/Sign-up/sign_up.js
@@ -23,7 +23,12 @@ export const sign_up_user = (user, div, nav) => {
 
             .then(res => res.json())
             .then(data => {
+                const evt = document.createEvent('StorageEvent');
+                evt.initStorageEvent('storage', false, false, 'user', '', JSON.stringify(data),null, window.localStorage);
+
                 localStorage.setItem('user', JSON.stringify(data))
+
+                window.dispatchEvent(evt);
                 nav('/')
             })
             .catch(err => {


### PR DESCRIPTION
@kamiri-charles 

With the help of a much smarter friend of mine, I was able to come up with a solution that allows Header to rerender on sign-in/sign-up without duplicating the element on the DOM.

It's pretty simple, but basically a custom hook is created inside Header to add an event listener to storage and update state accordingly.

Additionally, when sign-in/sign-up add the user to localStorage, it also now dispatches an event that "changes" localStorage in order to trigger the event listener.