### PR TITLE
Closes #11 Creates way for users to sign out

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import Loader from 'react-loaders';
+import SignOut from '../Sign-out'
 import './styles.scss';
 
 const useLocalStorage = (key) => {
@@ -12,7 +13,7 @@ const useLocalStorage = (key) => {
           setValue(null);
         } else if (event.key === key) {
           // the value we're watching changed. Update it.
-          setValue(JSON.parse(event.newValue).username);
+          setValue(JSON.parse(event.newValue).username || null);
         }
       }
       // User already exists in local storage
@@ -28,11 +29,12 @@ const useLocalStorage = (key) => {
       }
     }, [key]);
 
-    return value;
+    return value
   }
 
 const Header = () => {
     const user = useLocalStorage('user');
+    const [signOut, setSignOut] = useState(false);
 
     return (
         <div className="header">
@@ -41,13 +43,17 @@ const Header = () => {
                 <span className='bx-sm'>Notes</span>
             </div>
 
-            <div className="r">
+            <div className="r"
+                 onClick={() => localStorage.removeItem('user')}
+                 onMouseEnter={() => setSignOut(true)}
+                 onMouseLeave={() => setSignOut(false)}>
                 {user === undefined ? <Loader type='ball-pulse' /> : (
                     <>
                         <i className='bx bx-user bx-md'></i>
                         <span>{user}</span>
                     </>
                 )}
+                {signOut ? <SignOut user={user} /> : null}
             </div>
         </div>
     )

--- a/src/components/Header/styles.scss
+++ b/src/components/Header/styles.scss
@@ -20,6 +20,7 @@
     .r {
         display: grid;
         place-items: center;
+        position: relative;
     }
-        
+
 }

--- a/src/components/Header/styles.scss
+++ b/src/components/Header/styles.scss
@@ -21,6 +21,7 @@
         display: grid;
         place-items: center;
         position: relative;
+        width: max-content;
     }
 
 }

--- a/src/components/Notes/index.jsx
+++ b/src/components/Notes/index.jsx
@@ -20,6 +20,7 @@ const Notes = () => {
     }, [])
 
     let create_note = async () => {
+        setLoading(true)
         let user = JSON.parse(localStorage.getItem('user'))
 
         fetch('https://notes-app-api.azurewebsites.net/api/note/new/', {
@@ -38,7 +39,6 @@ const Notes = () => {
             fetch_notes()
             setNote(data)
             setLoading(false)
-
         })
     }
 

--- a/src/components/Notes/index.jsx
+++ b/src/components/Notes/index.jsx
@@ -13,14 +13,15 @@ const Notes = () => {
     let notes_nav = useRef()
     let menu_icon = useRef()
     const[loading, setLoading] = useState(true)
-    
+
     const update_state_from_child = useCallback(() => {
         fetch_notes()
     }, [])
 
     let create_note = async () => {
-        setLoading(true)
         let user = JSON.parse(localStorage.getItem('user'))
+        let tempNotes = notes.concat(['new']);
+        setNotes(tempNotes);
 
         fetch('https://notes-app-api.azurewebsites.net/api/note/new/', {
             method: 'POST',
@@ -37,19 +38,28 @@ const Notes = () => {
         .then(data => {
             fetch_notes()
             setNote(data)
-            setLoading(false)
 
         })
     }
 
     let fetch_notes = async () => {
+        if (!notes.length) {
+            setLoading(true);
+        }
         fetch(`https://notes-app-api.azurewebsites.net/api/notes/${JSON.parse(localStorage.getItem('user')).username}/`)
         .then(res => res.json())
-        .then(data => setNotes(data))
-        setLoading(false)
+        .then(data => {
+            if (!notes.length) {
+                setLoading(false);
+            }
+            setNotes(data)
+        })
     }
 
     let delete_note = async (note_id) => {
+        let tempNotes = notes.slice(0, notes.length - 1)
+        setNotes(tempNotes)
+        setNote(undefined)
         fetch(`https://notes-app-api.azurewebsites.net/api/notes/delete/${note_id}/`, {
             method: 'DELETE'
         })
@@ -60,7 +70,7 @@ const Notes = () => {
         })
     }
 
-    
+
 
     useEffect(() => {
         if (localStorage.getItem('user')) {
@@ -88,35 +98,46 @@ const Notes = () => {
             <div className="nav" ref={notes_nav}>
                 <div className="title">My Notes.</div>
                 {loading? (
-                   <div className='new-note'>
-                   <InfinitySpin 
-                    width='200'
-                    color="purple"
+                  <div className='new-note'>
+                    <InfinitySpin
+                        width='200'
+                        color="purple"
                     />
                   </div>
                 ):(
                     <>
-                      {notes?.map(note_instance => (
-                    <div key={note_instance.id} className="note" onClick={() => {
-                        setNote(note_instance)
-                        notes_nav.current.classList.remove('active')
-                        menu_icon.current.classList.remove('bx-x')
-                        menu_icon.current.classList.add('bx-menu')
-                        }}>
-                            {note_instance.title}
-            
-                            <span className="date">{
-                                new Date(note_instance.updated_at).toLocaleDateString()
-                            }</span>
+                      {notes?.map(note_instance => {
+                        return note_instance === 'new' ?
+                            (
+                                <div key={Math.random()} className='new-note new-note-spinner'>
+                                    <InfinitySpin
+                                        width='100'
+                                        height='50'
+                                        color="purple"
+                                    />
+                                </div>
+                            ):(
+                                <div key={note_instance.id} className="note" onClick={() => {
+                                    setNote(note_instance)
+                                    notes_nav.current.classList.remove('active')
+                                    menu_icon.current.classList.remove('bx-x')
+                                    menu_icon.current.classList.add('bx-menu')
+                                    }}>
+                                        {note_instance.title}
 
-                            <span className="delete" onClick={() => delete_note(note_instance.id)}>
-                                <i className='bx bx-trash-alt'></i>
-                            </span>
-                    </div>
-                ))}
+                                        <span className="date">{
+                                            new Date(note_instance.updated_at).toLocaleDateString()
+                                        }</span>
+
+                                        <span className="delete" onClick={() => delete_note(note_instance.id)}>
+                                            <i className='bx bx-trash-alt'></i>
+                                        </span>
+                                </div>
+                            )
+                      })}
                     </>
                 )}
-            
+
                 <button className="new-note" onClick={create_note}>
                     <i className="bx bx-plus"></i>
                 </button>

--- a/src/components/Notes/index.jsx
+++ b/src/components/Notes/index.jsx
@@ -80,6 +80,24 @@ const Notes = () => {
         } else {
             nav('/sign-in')
         }
+
+        const updateValue = (event) => {
+            const oldUsername = JSON.parse(event.oldValue).username;
+            const newUsername = JSON.parse(event.newValue).username;
+
+            if (oldUsername &&
+                !newUsername &&
+                event.key === 'user') {
+              nav('/sign-in')
+            }
+          }
+
+          window.addEventListener('storage', updateValue, false);
+          return () => {
+            window.removeEventListener('storage', updateValue, false);
+          }
+
+
     }, [nav])
 
     return (

--- a/src/components/Notes/styles.scss
+++ b/src/components/Notes/styles.scss
@@ -30,7 +30,7 @@
             opacity: 1;
         }
     }
-    
+
     .nav {
         width: 30%;
         height: 80vh;
@@ -52,14 +52,14 @@
                 left: 0;
             }
         }
-        
+
         .title {
             padding: 20px;
             font-size: 20px;
             font-family: 'Ubuntu', sans-serif;
             text-decoration: underline;
         }
-        
+
         .note {
             position: relative;
             padding: 20px;
@@ -68,11 +68,11 @@
             background: #eee;
             cursor: pointer;
             transition: all 0.2s ease-in-out;
-            
+
             &:hover {
                 background: #ddd;
             }
-            
+
             .date {
                 font-size: 12px;
                 color: #000;
@@ -80,14 +80,14 @@
                 top: 60%;
                 right: 10px;
             }
-            
+
             .delete {
                 position: absolute;
                 top: 10px;
                 right: 10px;
                 cursor: pointer;
                 transition: all 0.2s ease-in-out;
-                
+
                 &:hover {
                     color: red;
                 }
@@ -110,6 +110,14 @@
                 color: white;
                 font-size: 25px;
                 cursor: pointer;
+            }
+        }
+
+        .new-note-spinner {
+            padding: 9.5px calc(25% - 5px) 9px calc(25% - 50px);
+            background: white;
+            &:hover {
+                background: white;
             }
         }
     }

--- a/src/components/Notes/styles.scss
+++ b/src/components/Notes/styles.scss
@@ -117,13 +117,5 @@
                 cursor: pointer;
             }
         }
-
-        .new-note-spinner {
-            padding: 9.5px calc(25% - 5px) 9px calc(25% - 50px);
-            background: white;
-            &:hover {
-                background: white;
-            }
-        }
     }
 }

--- a/src/components/Sign-out/index.jsx
+++ b/src/components/Sign-out/index.jsx
@@ -1,0 +1,11 @@
+import { sign_out_user } from './sign_out'
+import './styles.scss';
+
+const SignOut = ({ user }) => {
+    return user ?
+            <div className="sign-out" onClick={() => sign_out_user(user)}>Sign Out</div>
+            :
+            <div className="sign-out"></div>;
+}
+
+export default SignOut;

--- a/src/components/Sign-out/sign_out.js
+++ b/src/components/Sign-out/sign_out.js
@@ -1,0 +1,33 @@
+import Cookies from 'js-cookie'
+
+export const sign_out_user = (user, div) => {
+    (async () => {
+        fetch(`https://notes-app-api.azurewebsites.net/api/user/sign-out/?username=${JSON.stringify(user)}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': Cookies.get('csrftoken')
+            }
+        })
+
+        .then(res => res.json())
+        .then(data => {
+            if (data.err) {
+                //Not sure yet what to do with this, if anything.
+                //div.current.innerText = data.err
+            } else {
+                const evt = document.createEvent('StorageEvent');
+                evt.initStorageEvent('storage',
+                                     false,
+                                     false,
+                                     'user',
+                                     JSON.stringify({ username: true }),
+                                     JSON.stringify({ username: false }),
+                                     null,
+                                     window.localStorage);
+
+                window.dispatchEvent(evt);
+            }
+        })
+    }) ()
+}

--- a/src/components/Sign-out/styles.scss
+++ b/src/components/Sign-out/styles.scss
@@ -1,0 +1,10 @@
+.sign-out {
+    font-family: 'Sedgwick Ave';
+    text-align: center;
+    position: absolute;
+    top: 54.5px;
+
+    &:hover {
+        cursor: pointer;
+    }
+}

--- a/src/components/Sign-out/styles.scss
+++ b/src/components/Sign-out/styles.scss
@@ -1,5 +1,6 @@
 .sign-out {
     font-family: 'Sedgwick Ave';
+    width: 70px;
     text-align: center;
     position: absolute;
     top: 54.5px;

--- a/src/components/Sign-up/styles.scss
+++ b/src/components/Sign-up/styles.scss
@@ -4,7 +4,7 @@
     align-items: center;
     justify-content: center;
     margin: 20px;
-    
+
     form {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Added a sign out component and related files.

The sign out component exists outside the routes, because I thought it worked best in the header.

However, that made navigating back to the `/sign-in` route from within the sign out component tricky.

I leveraged similar localStorage listening functionality from Header and placed it in Notes to listen for the custom event dispatching of the removal of user.

The styling is not ideal, but I didn't want to make judgement calls on that.



